### PR TITLE
#1 [feat]: API_KEY 작동 방식 수정

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="AlwaysBeWithYou.app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/main/java/com/example/alwaysbewithyou/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/alwaysbewithyou/presentation/main/MainActivity.kt
@@ -20,6 +20,8 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.navigation.compose.rememberNavController
 import com.example.alwaysbewithyou.R
 import com.example.alwaysbewithyou.ui.theme.AlwaysBeWithYouTheme
+import com.google.android.libraries.places.api.Places
+import timber.log.Timber
 import java.util.Date
 import java.util.Locale
 
@@ -29,6 +31,19 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val apiKey = try {
+            val appInfo = packageManager.getApplicationInfo(packageName, android.content.pm.PackageManager.GET_META_DATA)
+            appInfo.metaData.getString("com.google.android.geo.API_KEY")
+        } catch (e: Exception) {
+            null
+        }
+
+        apiKey?.let {
+            if (!Places.isInitialized()) {
+                Places.initialize(applicationContext, it)
+            }
+        }
         setContent {
             AlwaysBeWithYouTheme {
                 val navController = rememberNavController()

--- a/app/src/main/java/com/example/alwaysbewithyou/presentation/map/MapScreen.kt
+++ b/app/src/main/java/com/example/alwaysbewithyou/presentation/map/MapScreen.kt
@@ -130,20 +130,12 @@ fun MapScreen(
         position = CameraPosition.fromLatLngZoom(currentLocation ?: singapore, 10f)
     }
 
-    // 현재 위치가 업데이트되면 카메라를 해당 위치로 이동 (선택 사항)
     LaunchedEffect(currentLocation) {
         currentLocation?.let {
             cameraPositionState.animate(
                 update = CameraUpdateFactory.newLatLngZoom(it, 15f), // 줌 레벨 조정
                 durationMs = 1000
             )
-            // !!! 중요: MapScreen에서 초기 주변 검색을 제거합니다. !!!
-            // 이전 코드:
-            // if (searchText.isBlank() && searchState is SearchState.Idle) {
-            //     viewModel.searchPlacesNearby(it.latitude, it.longitude, null)
-            //     Timber.d("현재 위치 기반 초기 검색 시작 (MapScreen에만 표시): ${it.latitude}, ${it.longitude}")
-            // }
-            // 이 부분을 제거하여 MapScreen 로드 시 자동 주변 검색을 하지 않습니다.
         }
     }
 
@@ -156,8 +148,8 @@ fun MapScreen(
             trailingIcon = {
                 IconButton(onClick = {
                     // 사용자가 검색 아이콘 클릭 시: 현재 위치 기반 검색 시작 후 MapListScreen으로 이동
-                    viewModel.searchPlaces(searchText, currentLocation) // 현재 위치 전달
-                    onNavigateToMapList() // 이 부분에서 내비게이션을 트리거합니다.
+                    viewModel.searchPlaces(searchText)
+                    onNavigateToMapList()
                 }) {
                     Icon(Icons.Filled.Search, contentDescription = "검색")
                 }
@@ -168,8 +160,8 @@ fun MapScreen(
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             keyboardActions = KeyboardActions(onSearch = {
                 // 키보드 검색 버튼 클릭 시: 현재 위치 기반 검색 시작 후 MapListScreen으로 이동
-                viewModel.searchPlaces(searchText, currentLocation) // 현재 위치 전달
-                onNavigateToMapList() // 이 부분에서 내비게이션을 트리거합니다.
+                viewModel.searchPlaces(searchText)
+                onNavigateToMapList()
             })
         )
 
@@ -192,27 +184,7 @@ fun MapScreen(
                         zoomControlsEnabled = false // 줌 컨트롤 비활성화 (선택 사항)
                     )
                 ) {
-                    // 이제 MapScreen에서는 검색 결과 마커를 표시하지 않습니다.
-                    // 마커 표시는 MapListScreen에서 담당하거나, 별도의 로직으로 추가할 수 있습니다.
-                    /*
-                    if (searchState is SearchState.Success && searchText.isBlank()) {
-                        (searchState as SearchState.Success).results.forEach { place ->
-                            place.geometry?.location?.let { loc ->
-                                com.google.maps.android.compose.Marker(
-                                    state = com.google.maps.android.compose.rememberMarkerState(
-                                        position = LatLng(loc.lat ?: 0.0, loc.lng ?: 0.0)
-                                    ),
-                                    title = place.name,
-                                    snippet = place.formattedAddress,
-                                    onClick = { marker ->
-                                        place.placeId?.let { onPlaceClick(it) }
-                                        true
-                                    }
-                                )
-                            }
-                        }
-                    }
-                    */
+
                 }
             } else {
                 GoogleMap(

--- a/app/src/main/java/com/example/alwaysbewithyou/presentation/map/tools/MapViewModel.kt
+++ b/app/src/main/java/com/example/alwaysbewithyou/presentation/map/tools/MapViewModel.kt
@@ -24,30 +24,26 @@ class MapViewModel(
     private val placeRepository: PlaceRepository // PlaceRepository 주입
 ) : ViewModel() {
 
-    // 기본 생성자
-    constructor() : this(
-        PlaceRepository(
-            RetrofitClient.googlePlacesApiService,
-            BuildConfig.API_KEY
-        )
-    )
-
     private val _searchResults = MutableStateFlow<SearchState>(SearchState.Idle)
     val searchResults: StateFlow<SearchState> = _searchResults.asStateFlow()
 
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
+    private val _currentLocation = MutableStateFlow<android.location.Location?>(null)
+    val currentLocation: StateFlow<android.location.Location?> = _currentLocation.asStateFlow()
+
     fun updateSearchQuery(query: String) {
         _searchQuery.value = query
     }
 
-    /**
-     * 텍스트 쿼리를 기반으로 장소를 검색합니다 (검색바 입력용).
-     * @param query 검색어
-     * @param currentLocation 현재 위치 (선택 사항). 제공되면 주변 검색을 수행합니다.
-     */
-    fun searchPlaces(query: String, currentLocation: LatLng? = null) {
+    fun updateCurrentLocation(location: android.location.Location?) {
+        _currentLocation.value = location
+    }
+
+    fun searchPlaces(query: String) {
+        val currentLocation = _currentLocation.value
+
         if (query.isBlank() && currentLocation == null) { // 검색어 없고 위치도 없으면 Idle
             _searchResults.value = SearchState.Idle
             return
@@ -81,7 +77,7 @@ class MapViewModel(
         }
     }
 
-
+    // gps 주변으로 검색 구현해야 함
     fun searchPlacesNearby(latitude: Double, longitude: Double, query: String? = null) {
 
     }

--- a/app/src/main/java/com/example/alwaysbewithyou/presentation/map/tools/PlaceRepository.kt
+++ b/app/src/main/java/com/example/alwaysbewithyou/presentation/map/tools/PlaceRepository.kt
@@ -1,5 +1,8 @@
 package com.example.alwaysbewithyou.presentation.map.tools
 
+import android.R.attr.apiKey
+import android.content.Context
+import android.content.pm.PackageManager
 import com.example.alwaysbewithyou.presentation.map.tools.GooglePlacesApiService
 import com.example.alwaysbewithyou.presentation.map.tools.GooglePlacesApiService.PlaceResult
 import kotlinx.coroutines.Dispatchers
@@ -8,8 +11,17 @@ import timber.log.Timber
 
 class PlaceRepository(
     private val apiService: GooglePlacesApiService,
-    private val apiKey: String
+    private val context: Context
 ) {
+    private val apiKey: String by lazy {
+        val applicationInfo = context.packageManager.getApplicationInfo(
+            context.packageName,
+            PackageManager.GET_META_DATA
+        )
+        applicationInfo.metaData.getString("com.google.android.geo.API_KEY")
+            ?: throw IllegalStateException("API_KEY not found in AndroidManifest.xml")
+    }
+
     suspend fun getPlaceDetails(placeId: String): PlaceResult? {
         return withContext(Dispatchers.IO) {
             try {
@@ -55,17 +67,16 @@ class PlaceRepository(
         latitude: Double,
         longitude: Double,
         query: String?,
-        radius: Int // MapViewModel에서 50000으로 넘겨주므로 추가
+        radius: Int
     ): List<PlaceResult> {
         return withContext(Dispatchers.IO) {
             try {
                 val location = "$latitude,$longitude"
                 val response = apiService.nearbySearch(
                     location = location,
-                    radius = radius, // 반경 파라미터 사용
-                    keyword = query, // 검색 키워드가 있다면 사용
+                    radius = radius,
+                    keyword = query,
                     apiKey = apiKey
-                    // type 등 추가 파라미터 필요시 여기에 추가
                 )
 
                 if (response.status == "OK") {

--- a/app/src/main/java/com/example/alwaysbewithyou/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/alwaysbewithyou/presentation/navigation/NavGraph.kt
@@ -3,6 +3,7 @@ package com.example.alwaysbewithyou.presentation.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -10,7 +11,6 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.example.alwaysbewithyou.BuildConfig
 import com.example.alwaysbewithyou.LoginScreen
 import com.example.alwaysbewithyou.presentation.call.CallScreen
 import com.example.alwaysbewithyou.presentation.guardian.GuardianScreen
@@ -35,7 +35,7 @@ fun NavGraph(
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
-    val mapViewModel: MapViewModel = viewModel()
+    val context = LocalContext.current
 
     val retrofit = remember {
         Retrofit.Builder()
@@ -45,7 +45,19 @@ fun NavGraph(
     }
 
     val googlePlacesApiService = remember { retrofit.create(GooglePlacesApiService::class.java) }
-    val placeRepository = remember { PlaceRepository(googlePlacesApiService, BuildConfig.API_KEY) }
+    val placeRepository = remember { PlaceRepository(googlePlacesApiService, context) }
+
+    val mapViewModel: MapViewModel = viewModel(
+        factory = object : ViewModelProvider.Factory {
+            override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+                if (modelClass.isAssignableFrom(MapViewModel::class.java)) {
+                    @Suppress("UNCHECKED_CAST")
+                    return MapViewModel(placeRepository) as T
+                }
+                throw IllegalArgumentException("Unknown ViewModel class")
+            }
+        }
+    )
 
     NavHost(
         navController = navController,


### PR DESCRIPTION
📌 Related Issue
- API 수정 #1

🚀 Description
- API_KEY를 가져오는 방식을 기존의 BuildConfig에서 plugin을 통해 secreats.properties에서 가져오는 방식으로 변경했습니다. 
- API_KEY의 작동 방식 변경에 따라 PlaceReopsitory.kt, NavGraph.kt, MapViewModel.kt, MapScreen.kt를 수정했습니다.
- MainActivity.kt에 Places.initialize() 부분이 누락되어 추가했습니다.

📢 Notes
- secrets.properties 파일은 제 api key 정보가 들어있으므로, 최종 제출할때는 제외하고, local.defaults.properties에 사용자가 api key를 등록해서 사용하도록 설명해야 합니다.